### PR TITLE
Add Postnord API client and Shipment Resource

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,24 +1,171 @@
-# PostnordApi
+# PostNord Ruby Gem
 
-TODO: Delete this and the text below, and describe your gem
+A Ruby wrapper for the PostNord API that provides simple access to booking return and tracking shipment.
 
-Welcome to your new gem! In this directory, you'll find the files you need to be able to package up your Ruby library into a gem. Put your Ruby code in the file `lib/postnord_api`. To experiment with that code, run `bin/console` for an interactive prompt.
+## Features
+
+- **Return Booking**: Create return shipment using EDI formatting
+- **Shipment Tracking**: Track shipment by identifier
 
 ## Installation
 
-TODO: Replace `UPDATE_WITH_YOUR_GEM_NAME_IMMEDIATELY_AFTER_RELEASE_TO_RUBYGEMS_ORG` with your gem name right after releasing it to RubyGems.org. Please do not do it earlier due to security reasons. Alternatively, replace this section with instructions to install your gem from git if you don't plan to release to RubyGems.org.
+Add this line to your application's Gemfile:
 
-Install the gem and add to the application's Gemfile by executing:
+```ruby
+gem 'postnord_api'
+```
 
-    $ bundle add UPDATE_WITH_YOUR_GEM_NAME_IMMEDIATELY_AFTER_RELEASE_TO_RUBYGEMS_ORG
+And then execute:
 
-If bundler is not being used to manage dependencies, install the gem by executing:
+    $ bundle install
 
-    $ gem install UPDATE_WITH_YOUR_GEM_NAME_IMMEDIATELY_AFTER_RELEASE_TO_RUBYGEMS_ORG
+Or install it yourself as:
+
+    $ gem install postnord_api
 
 ## Usage
 
-TODO: Write usage instructions here
+### Intialize a Postnord API client
+
+- For production usage:
+
+```ruby
+client = PostnordAPI::Client.new(api_key: "api_key")
+```
+
+- For development usage:
+
+```ruby
+client = PostnordAPI::Client.new(api_key: "api_key", test_mode: true)
+```
+
+### Create Return Shipmemt
+
+```ruby
+begin
+   client = PostnordAPI::Client.new(api_key: "api_key")
+   params = {
+      "messageDate": '2025-09-23T11:40:52Z',
+      "messageFunction": 'Instruction',
+      "messageId": 'msg-18272155',
+      "application": {
+        "applicationId": 1438,
+        "name": 'PostNord',
+        "version": '1.0'
+      },
+      "language": 'EN',
+      "updateIndicator": 'Original',
+      "shipment": [
+        {
+          "shipmentIdentification": {
+            "shipmentId": '0'
+          },
+          "dateAndTimes": {
+            "loadingDate": '2020-11-29T11:13:00'
+          },
+          "service": {
+            "basicServiceCode": '24',
+            "additionalServiceCode": []
+          },
+          "numberOfPackages": {
+            "value": 1
+          },
+          "totalGrossWeight": {
+            "value": 5.23,
+            "unit": 'KGM'
+          },
+          "references": [
+            {
+              "referenceNo": '61G33IGAPTVZPY5',
+              "referenceType": 'CU'
+            }
+          ],
+          "parties": {
+            "consignor": {
+              "issuerCode": 'Z12',
+              "partyIdentification": {
+                "partyId": '1111111111',
+                "partyIdType": '160'
+              },
+              "party": {
+                "nameIdentification": {
+                  "name": 'CONSIGNOR'
+                },
+                "address": {
+                  "streets": [
+                    'Terminalvägen 14'
+                  ],
+                  "postalCode": '17173',
+                  "city": 'solna',
+                  "countryCode": 'SE'
+                },
+                "contact": {
+                  "contactName": 'Consignor',
+                  "emailAddress": 'Consignor@me.com',
+                  "phoneNo": '+46071111111',
+                  "smsNo": '+46071111111'
+                }
+              }
+            },
+            "consignee": {
+              "party": {
+                "nameIdentification": {
+                  "name": 'Consignee'
+                },
+                "address": {
+                  "streets": [
+                    'Östermalmsgatan 87D'
+                  ],
+                  "postalCode": '11459',
+                  "city": 'STOCKHOLM',
+                  "countryCode": 'SE'
+                },
+                "contact": {
+                  "contactName": 'Consignee',
+                  "emailAddress": 'Consignee@me.com',
+                  "phoneNo": '+46071111111',
+                  "smsNo": '+46071111111'
+                }
+              }
+            }
+          },
+          "goodsItem": [
+            {
+              "marking": 'Description of the commodities',
+              "goodsDescription": 'goodsDescription',
+              "packageTypeCode": 'PC',
+              "items": [
+                {
+                  "itemIdentification": {
+                    "itemId": '0'
+                  }
+                }
+              ]
+            }
+          ]
+        }
+      ]
+    }
+
+  client.shipment.create_return_label(params)
+  # The result contains the label data, QR code data and tracking URL.
+
+rescue PostnordAPI::Error => e
+  puts "Error creating return shipment: #{e.message}"
+end
+```
+
+### Track Shipment
+
+```ruby
+begin
+  # Track shipment by identifier
+  client.shipment.track("1234567890")
+
+rescue PostnordAPI::APIError => e
+  puts "Tracking failed: #{e.message}"
+end
+```
 
 ## Development
 
@@ -28,7 +175,7 @@ To install this gem onto your local machine, run `bundle exec rake install`. To 
 
 ## Contributing
 
-Bug reports and pull requests are welcome on GitHub at https://github.com/[USERNAME]/postnord_api. This project is intended to be a safe, welcoming space for collaboration, and contributors are expected to adhere to the [code of conduct](https://github.com/[USERNAME]/postnord_api/blob/main/CODE_OF_CONDUCT.md).
+Bug reports and pull requests are welcome on GitHub at https://github.com/PostCo/postnord_api. This project is intended to be a safe, welcoming space for collaboration, and contributors are expected to adhere to the [code of conduct](https://github.com/[USERNAME]/postnord_api/blob/main/CODE_OF_CONDUCT.md).
 
 ## License
 

--- a/lib/postnord_api.rb
+++ b/lib/postnord_api.rb
@@ -1,8 +1,26 @@
 # frozen_string_literal: true
 
 require_relative 'postnord_api/version'
+require 'zeitwerk'
+
+loader = Zeitwerk::Loader.for_gem
+loader.inflector.inflect('postnord_api' => 'PostnordAPI')
 
 module PostnordAPI
-  class Error < StandardError; end
-  # Your code goes here...
+  # Core components
+  autoload :Client, 'postnord_api/client'
+  autoload :Error, 'postnord_api/errors'
+  autoload :BadRequestError, 'postnord_api/errors'
+  autoload :ForbiddenError, 'postnord_api/errors'
+  autoload :RateLimitError, 'postnord_api/errors'
+  autoload :ServerError, 'postnord_api/errors'
+
+  # Resources
+  autoload :BaseResource, 'postnord_api/resources/base_resource'
+  autoload :ShipmentResource, 'postnord_api/resources/shipment_resource'
+
+  # Objects
+  autoload :Base, 'postnord_api/objects/base'
+  autoload :Booking, 'postnord_api/objects/booking'
+  autoload :Tracking, 'postnord_api/objects/tracking'
 end

--- a/lib/postnord_api/client.rb
+++ b/lib/postnord_api/client.rb
@@ -1,0 +1,39 @@
+# frozen_string_literal: true
+
+require 'faraday'
+require 'faraday/net_http'
+
+module PostnordAPI
+  class Client
+    BASE_URL = 'https://api2.postnord.com/rest'
+    SANDBOX_BASE_URL = 'https://atapi2.postnord.com/rest'
+
+    def initialize(api_key:, test_mode: false)
+      @api_key = api_key
+      @test_mode = test_mode
+    end
+
+    def connection
+      @connection ||=
+        Faraday.new do |conn|
+          conn.url_prefix = url_prefix
+          conn.request :json
+          conn.headers = { 'Content-Type' => 'application/json' }
+          conn.params[:apikey] = api_key
+          conn.response :json, content_type: 'application/json'
+        end
+    end
+
+    def shipment
+      @shipment ||= ShipmentResource.new(self)
+    end
+
+    private
+
+    attr_reader :api_key, :test_mode
+
+    def url_prefix
+      test_mode ? SANDBOX_BASE_URL : BASE_URL
+    end
+  end
+end

--- a/lib/postnord_api/errors.rb
+++ b/lib/postnord_api/errors.rb
@@ -1,0 +1,9 @@
+# frozen_string_literal: true
+
+module PostnordAPI
+  class Error < StandardError; end
+  class BadRequestError < Error; end
+  class ForbiddenError < Error; end
+  class RateLimitError < Error; end
+  class ServerError < Error; end
+end

--- a/lib/postnord_api/objects/base.rb
+++ b/lib/postnord_api/objects/base.rb
@@ -1,0 +1,44 @@
+# frozen_string_literal: true
+
+require 'active_support'
+require 'active_support/core_ext/string'
+require 'ostruct'
+
+module PostnordAPI
+  class Base < OpenStruct
+    def initialize(attributes)
+      super to_ostruct(attributes)
+    end
+
+    def to_ostruct(obj)
+      if obj.is_a?(Hash)
+        OpenStruct.new(obj.map { |key, val| [key.to_s.underscore, to_ostruct(val)] }.to_h)
+      elsif obj.is_a?(Array)
+        obj.map { |o| to_ostruct(o) }
+      else # Assumed to be a primitive value
+        obj
+      end
+    end
+
+    # Convert back to hash without table key, including nested structures
+    def to_hash
+      ostruct_to_hash(self)
+    end
+
+    private
+
+    def ostruct_to_hash(object)
+      case object
+      when OpenStruct
+        hash = object.to_h.reject { |k, _| k == :table }
+        hash.transform_values { |value| ostruct_to_hash(value) }
+      when Array
+        object.map { |item| ostruct_to_hash(item) }
+      when Hash
+        object.transform_values { |value| ostruct_to_hash(value) }
+      else
+        object
+      end
+    end
+  end
+end

--- a/lib/postnord_api/objects/booking.rb
+++ b/lib/postnord_api/objects/booking.rb
@@ -1,0 +1,6 @@
+# frozen_string_literal: true
+
+module PostnordAPI
+  class Booking < Base
+  end
+end

--- a/lib/postnord_api/objects/tracking.rb
+++ b/lib/postnord_api/objects/tracking.rb
@@ -1,0 +1,6 @@
+# frozen_string_literal: true
+
+module PostnordAPI
+  class Tracking < Base
+  end
+end

--- a/lib/postnord_api/resources/base_resource.rb
+++ b/lib/postnord_api/resources/base_resource.rb
@@ -1,0 +1,58 @@
+# frozen_string_literal: true
+
+module PostnordAPI
+  class BaseResource
+    attr_reader :client
+
+    def initialize(client)
+      @client = client
+    end
+
+    protected
+
+    def get_request(url, params: {}, headers: {})
+      handle_response(client.connection.get(url, params, headers))
+    end
+
+    def post_request(url, body: {}, headers: {})
+      handle_response(client.connection.post(url, body, headers))
+    end
+
+    def handle_response(response)
+      case response.status
+      when 200..299
+        response
+      else
+        handle_error(response)
+      end
+    end
+
+    def handle_error(response)
+      error_message = extract_error_message(response.body)
+
+      case response.status
+      when 400
+        raise Error, "A bad request or a validation exception has occurred. #{error_message}"
+      when 403
+        raise ForbiddenError, "Invalid API key. #{error_message}"
+      when 429
+        raise RateLimitError, "The API rate limit for your application has been exceeded. #{error_message}"
+      when 500
+        raise ServerError, "An unhandled error with the PostNord API. #{error_message}"
+      end
+    end
+
+    private
+
+    def extract_error_message(body)
+      case body
+      when String
+        body
+      when Hash
+        body['error'] || body['message'] || body.to_s
+      else
+        'Unknown error'
+      end
+    end
+  end
+end

--- a/lib/postnord_api/resources/shipment_resource.rb
+++ b/lib/postnord_api/resources/shipment_resource.rb
@@ -1,0 +1,15 @@
+# frozen_string_literal: true
+
+module PostnordAPI
+  class ShipmentResource < BaseResource
+    def create_return_label(params)
+      response = post_request("shipment/v3/returns/edi/labels/zpl", body: params)
+      Booking.new(response.body)
+    end
+
+    def track(tracking_number, locale: "en")
+      response = get_request("shipment/v5/trackandtrace/findByIdentifier.json?id=#{tracking_number}&locale=#{locale}")
+      Tracking.new(response.body)
+    end
+  end
+end


### PR DESCRIPTION
1. Add PostnordAPI::Client which accepts api_key and test_mode params
2. Add required resources and objects
- Add PostnordAPI::BaseResource which is the base class for all resources
- Add PostnordAPI::ShipmentResource which is the resource for the Shipment API
  - create_return_label method to create a return label
  - track method to track a shipment
- Add PostnordAPI::Base which is the base class for all objects
- Add PostnordAPI::Booking which is the object for the Shipment create return label
- Add PostnordAPI::Tracking which is the object for the Shipment track